### PR TITLE
fix: update Lynchburg Symphony Orchestra to audition-specific URL

### DIFF
--- a/urls.json
+++ b/urls.json
@@ -41,6 +41,6 @@
   },
   {
     "name": "Lynchburg Symphony Orchestra",
-    "url": "https://www.lynchburgsymphony.org/employment-opportunities/"
+    "url": "https://www.lynchburgsymphony.org/audition/"
   }
 ]


### PR DESCRIPTION
## Summary

- Replaces the generic employment-opportunities page with the dedicated `/audition/` page for Lynchburg Symphony Orchestra
- The old URL caused a preflight failure because it contained only staff job listings, not musician audition content

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)