### PR TITLE
fix: use domcontentloaded instead of networkidle2 in Puppeteer

### DIFF
--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -75,7 +75,7 @@ export async function fetchWithPuppeteer(url: string): Promise<string> {
     await page.setUserAgent(
       "Mozilla/5.0 (compatible; AuditionChecker/1.0; +https://github.com)"
     );
-    await page.goto(url, { waitUntil: "networkidle2", timeout: 30000 });
+    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30000 });
     // Wait a bit more for lazy-loaded content
     await new Promise((r) => setTimeout(r, 2000));
     return await page.content();


### PR DESCRIPTION
networkidle2 waits until there are ≤2 open network connections for 500ms, which modern sites with analytics/ads/chat widgets never reach within 30s. domcontentloaded fires as soon as the DOM is parsed; the existing 2-second post-navigation delay still provides a buffer for JS-rendered content.

Closes #7

Generated with [Claude Code](https://claude.ai/code)