### PR TITLE
fix: reduce hash churn with audition-signal filtering and add debug tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ Thumbs.db
 # Logs
 *.log
 npm-debug.log*
+debug.log
 
 # TypeScript cache
 *.tsbuildinfo

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
+        "dotenv": "^17.3.1",
         "googleapis": "^144.0.0",
         "puppeteer": "^22.0.0"
       },
@@ -1637,6 +1638,18 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "scripts": {
     "check": "ts-node src/check-auditions.ts",
     "check:dry": "DRY_RUN=true ts-node src/check-auditions.ts",
+    "check:debug": "DRY_RUN=true CHECKER_DEBUG=true ts-node src/check-auditions.ts",
     "test": "vitest run"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
+    "dotenv": "^17.3.1",
     "googleapis": "^144.0.0",
     "puppeteer": "^22.0.0"
   },

--- a/src/check-auditions.ts
+++ b/src/check-auditions.ts
@@ -24,9 +24,11 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import dotenv from "dotenv";
+dotenv.config({ path: ".env.local" });
 import Anthropic from "@anthropic-ai/sdk";
 
-import { contentHash } from "./scraper";
+import { computePageHash, normalizeForHash, extractAuditionSignals } from "./scraper";
 import { PlaybillFinding, PlaybillState, processPlaybillUrl } from "./playbill-crawler";
 import { UrlConfig, AuditionAnalysis, sendEmail } from "./email";
 import { analyzeWithClaude } from "./claude";
@@ -67,6 +69,14 @@ interface StateFile extends PlaybillState {
 
 const STATE_FILE = path.join(process.cwd(), "audition-state.json");
 const URLS_FILE = path.join(process.cwd(), "urls.json");
+const DEBUG_LOG_FILE = path.join(process.cwd(), "debug.log");
+
+// ─── Debug logger ─────────────────────────────────────────────────────────────
+
+function debugLog(line: string): void {
+  const entry = `[${new Date().toISOString()}] ${line}\n`;
+  fs.appendFileSync(DEBUG_LOG_FILE, entry, "utf-8");
+}
 
 // ─── State helpers ────────────────────────────────────────────────────────────
 
@@ -111,7 +121,10 @@ function saveState(state: StateFile): void {
  * of silently dropping a confirmed finding.
  */
 async function main(): Promise<void> {
-  console.log("🎺 Audition checker starting...\n");
+  const isDryRun = process.env.DRY_RUN === "true";
+  const isDebug = process.env.CHECKER_DEBUG === "true";
+  if (isDebug) fs.writeFileSync(DEBUG_LOG_FILE, "", "utf-8"); // clear on each run
+  console.log(`🎺 Audition checker starting...${isDryRun ? " (DRY RUN)" : ""}\n`);
 
   // Load URL list
   if (!fs.existsSync(URLS_FILE)) {
@@ -160,7 +173,7 @@ async function main(): Promise<void> {
         console.log(`  ⏭️  Skipping (failed preflight)`);
         continue;
       }
-      const hash = contentHash(text);
+      const hash = computePageHash(text);
       const previousState = state.pages[urlConfig.url];
 
       // Skip if content unchanged and we already checked it recently
@@ -169,6 +182,11 @@ async function main(): Promise<void> {
         continue;
       }
 
+      if (isDebug && previousState) {
+        const signals = extractAuditionSignals(normalizeForHash(text));
+        debugLog(`[${urlConfig.name}] hash: ${previousState.contentHash} → ${hash}`);
+        debugLog(`[${urlConfig.name}] hash input (${signals.length} chars):\n${signals}`);
+      }
       console.log(`  🔍 Content changed — analyzing with Claude...`);
       const analysis = await analyzeWithClaude(claude, text, urlConfig.url, urlConfig.name);
 
@@ -200,31 +218,59 @@ async function main(): Promise<void> {
     }
   }
 
-  // Persist updated state (including Playbill listing state)
-  state.lastRun = new Date().toISOString();
-  saveState(state);
-  console.log(`\n💾 State saved to ${STATE_FILE}`);
+  const hasFindings = newFindings.length > 0 || newPlaybillFindings.length > 0 || probeFailures.length > 0;
 
-  // Send email if there are new findings OR probe failures to report
-  if (newFindings.length > 0 || newPlaybillFindings.length > 0 || probeFailures.length > 0) {
-    const reason = [
-      newFindings.length > 0 ? `${newFindings.length} orchestra finding(s)` : "",
-      newPlaybillFindings.length > 0 ? `${newPlaybillFindings.length} Playbill finding(s)` : "",
-      probeFailures.length > 0 ? `${probeFailures.length} URL issue(s)` : "",
-    ].filter(Boolean).join(" + ");
-    console.log(`\n📬 Sending email (${reason})...`);
-    await sendEmail(newFindings, probeFailures, newPlaybillFindings);
-
-    // Mark Playbill findings as notified only after successful email send
-    for (const finding of newPlaybillFindings) {
-      if (state.playbillListings[finding.listingUrl]) {
-        state.playbillListings[finding.listingUrl].notified = true;
+  if (isDryRun) {
+    console.log("\n🧪 DRY RUN — state not saved, email not sent.\n");
+    if (hasFindings) {
+      if (newFindings.length > 0) {
+        console.log("── Orchestra findings ──");
+        for (const f of newFindings) {
+          console.log(`  ${f.config.name}: ${f.analysis.summary ?? "(no summary)"}`);
+          if (f.analysis.relevantItems.length > 0)
+            console.log(`    Items: ${f.analysis.relevantItems.join(", ")}`);
+        }
       }
+      if (newPlaybillFindings.length > 0) {
+        console.log("── Playbill findings ──");
+        for (const f of newPlaybillFindings)
+          console.log(`  ${f.title} — ${f.listingUrl}`);
+      }
+      if (probeFailures.length > 0) {
+        console.log("── Probe failures ──");
+        for (const f of probeFailures)
+          console.log(`  ${f.name}: ${f.detail}`);
+      }
+    } else {
+      console.log("✅ No new relevant auditions found.");
     }
-    // Save state again with updated notified flags
-    saveState(state);
   } else {
-    console.log("\n✅ No new relevant auditions found. No email sent.");
+    // Persist updated state (including Playbill listing state)
+    state.lastRun = new Date().toISOString();
+    saveState(state);
+    console.log(`\n💾 State saved to ${STATE_FILE}`);
+
+    // Send email if there are new findings OR probe failures to report
+    if (hasFindings) {
+      const reason = [
+        newFindings.length > 0 ? `${newFindings.length} orchestra finding(s)` : "",
+        newPlaybillFindings.length > 0 ? `${newPlaybillFindings.length} Playbill finding(s)` : "",
+        probeFailures.length > 0 ? `${probeFailures.length} URL issue(s)` : "",
+      ].filter(Boolean).join(" + ");
+      console.log(`\n📬 Sending email (${reason})...`);
+      await sendEmail(newFindings, probeFailures, newPlaybillFindings);
+
+      // Mark Playbill findings as notified only after successful email send
+      for (const finding of newPlaybillFindings) {
+        if (state.playbillListings[finding.listingUrl]) {
+          state.playbillListings[finding.listingUrl].notified = true;
+        }
+      }
+      // Save state again with updated notified flags
+      saveState(state);
+    } else {
+      console.log("\n✅ No new relevant auditions found. No email sent.");
+    }
   }
 
   console.log("\n🏁 Done.");

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -1,7 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { google } from "googleapis";
 
-import { MIN_CONTENT_LENGTH, fetchPage, fetchWithPuppeteer, stripHtml } from "./scraper";
+import { MIN_CONTENT_LENGTH, fetchPage, fetchWithPuppeteer, stripHtml, extractMainContent } from "./scraper";
 import { UrlConfig, ProbeFailure } from "./email";
 import { probeIsAuditionPage } from "./claude";
 
@@ -107,14 +107,14 @@ export async function preflightUrls(
 
       try {
         const html = await fetchPage(urlConfig.url);
-        text = stripHtml(html);
+        text = stripHtml(extractMainContent(html));
         if (text.length < MIN_CONTENT_LENGTH) {
           throw new Error(`Content too short (${text.length} chars)`);
         }
       } catch (fetchErr) {
         console.log(`    ↳ Fetch insufficient, trying Puppeteer...`);
         const html = await fetchWithPuppeteer(urlConfig.url);
-        text = stripHtml(html);
+        text = stripHtml(extractMainContent(html));
         usedPuppeteer = true;
       }
 

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -88,6 +88,7 @@ export async function fetchWithPuppeteer(url: string): Promise<string> {
 
 export function stripHtml(html: string): string {
   return html
+    .replace(/<!--[\s\S]*?-->/g, "")
     .replace(/<script[\s\S]*?<\/script>/gi, "")
     .replace(/<style[\s\S]*?<\/style>/gi, "")
     .replace(/<[^>]+>/g, " ")
@@ -97,6 +98,69 @@ export function stripHtml(html: string): string {
     .replace(/&gt;/g, ">")
     .replace(/\s{2,}/g, " ")
     .trim();
+}
+
+/**
+ * Strips common dynamic text patterns (timestamps, calendar dates) from stripped
+ * text before hashing. Used only for hash computation — Claude still receives
+ * the full stripped text.
+ */
+export function normalizeForHash(text: string): string {
+  return text
+    // Relative timestamps: "3 hours ago", "2 days ago", "just now", etc.
+    .replace(/\b\d+\s+(second|minute|hour|day|week|month|year)s?\s+ago\b/gi, "")
+    .replace(/\bjust now\b/gi, "")
+    .replace(/\byesterday\b/gi, "")
+    // "Last updated: ..." / "Last modified: ..." lines
+    .replace(/\blast\s+(updated|modified|checked)[^\n.]*/gi, "")
+    // WordPress post meta: "admin 2026-02-11T21:24:08+00:00" (author + ISO timestamp)
+    .replace(/\b\w+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[^\s]*/g, "")
+    // Collapse any newly created whitespace gaps
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
+/**
+ * Filters normalized text down to sentences that contain audition-relevant signals,
+ * plus short phrases (likely headings). Used as the final step before hashing so
+ * that rotating non-audition content (featured musician bios, news, event listings)
+ * does not cause spurious hash churn and unnecessary Claude re-analysis.
+ *
+ * Claude always receives the full stripped text — this function only affects the
+ * hash input.
+ */
+export function extractAuditionSignals(text: string): string {
+  const AUDITION_SIGNALS =
+    /\b(audition|vacancy|vacancies|position|opening|application|apply|deadline|excerpt|substitute|employment|hiring|compensation|pay)\b/i;
+
+  // Split on sentence-ending punctuation followed by a capital letter (new sentence)
+  const sentences = text.split(/(?<=[.!?;])\s+(?=[A-Z])/);
+
+  return sentences
+    .filter((s) => s.trim().length < 120 || AUDITION_SIGNALS.test(s))
+    .join(" ")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
+/**
+ * Extracts the primary content area from raw HTML to exclude navigation, headers,
+ * and footers before stripping. Tries semantic elements in priority order and falls
+ * back to the full HTML if none are found.
+ */
+export function extractMainContent(html: string): string {
+  const candidates = [
+    /<main[\s\S]*?>([\s\S]*?)<\/main>/i,
+    /<article[\s\S]*?>([\s\S]*?)<\/article>/i,
+    /<div[^>]+\bid=["'](?:main|content|page-content|main-content|primary)["'][^>]*>([\s\S]*)<\/div>/i,
+    /<div[^>]+\bclass=["'][^"']*\b(?:main-content|page-content|entry-content|post-content|site-content)\b[^"']*["'][^>]*>([\s\S]*)<\/div>/i,
+    /<div[^>]+\bclass=["']content["'][^>]*>([\s\S]*)<\/div>/i,
+  ];
+  for (const pattern of candidates) {
+    const match = html.match(pattern);
+    if (match) return match[1];
+  }
+  return html;
 }
 
 // ─── Scrape with fallback ─────────────────────────────────────────────────────
@@ -134,4 +198,9 @@ export async function scrapeUrl(url: string): Promise<string> {
 
 export function contentHash(text: string): string {
   return crypto.createHash("sha256").update(text).digest("hex").slice(0, 16);
+}
+
+/** Full hash pipeline: normalize → extract signals → SHA256. */
+export function computePageHash(text: string): string {
+  return contentHash(extractAuditionSignals(normalizeForHash(text)));
 }

--- a/tests/scraper.test.ts
+++ b/tests/scraper.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { stripHtml, contentHash, MIN_CONTENT_LENGTH } from "../src/scraper";
+import { stripHtml, contentHash, normalizeForHash, MIN_CONTENT_LENGTH } from "../src/scraper";
 
 describe("MIN_CONTENT_LENGTH", () => {
   it("is 500", () => {
@@ -87,5 +87,34 @@ describe("contentHash", () => {
     const hash = contentHash("");
     expect(hash).toHaveLength(16);
     expect(hash).toMatch(/^[0-9a-f]{16}$/);
+  });
+});
+
+describe("normalizeForHash", () => {
+  it("strips relative timestamps", () => {
+    expect(normalizeForHash("Posted 3 hours ago on our site")).toBe("Posted on our site");
+    expect(normalizeForHash("Updated 2 days ago")).toBe("Updated");
+    expect(normalizeForHash("Submitted 1 minute ago")).toBe("Submitted");
+  });
+
+  it("strips 'just now' and 'yesterday'", () => {
+    expect(normalizeForHash("Posted just now")).toBe("Posted");
+    expect(normalizeForHash("Last seen yesterday")).toBe("Last seen");
+  });
+
+  it("strips 'last updated/modified/checked' lines", () => {
+    expect(normalizeForHash("Last updated: Monday March 9")).toBe("");
+    expect(normalizeForHash("Last modified by admin")).toBe("");
+    expect(normalizeForHash("Last checked 2026-03-09")).toBe("");
+  });
+
+  it("preserves audition-relevant content", () => {
+    const text = "Trumpet audition August 12. Submit resume by July 1.";
+    expect(normalizeForHash(text)).toBe(text);
+  });
+
+  it("collapses whitespace after stripping", () => {
+    const result = normalizeForHash("Open positions  3 hours ago  apply now");
+    expect(result).toBe("Open positions apply now");
   });
 });


### PR DESCRIPTION
## Summary

- **Hash churn fix**: Adds `extractAuditionSignals()` to filter normalized page text down to only sentences containing audition-relevant keywords (audition, vacancy, position, apply, etc.) before hashing. Rotating non-audition content — featured musician bios, event listings, org history — is now excluded from the hash input, eliminating spurious Claude re-analysis on pages like Fayetteville Symphony (which rotates a "Featured Musician" bio on every request).
- **Pipeline composition**: Introduces `computePageHash(text)` to compose the full `normalizeForHash → extractAuditionSignals → contentHash` pipeline into a single readable call.
- **dotenv**: Loads `.env.local` automatically so `npm run check:dry` works locally without manually prefixing env vars.
- **Debug tooling**: Adds `npm run check:debug` (`DRY_RUN=true CHECKER_DEBUG=true`) which writes hash diffs and the exact hash input per URL to `debug.log` for diagnosing future churn. Uses `CHECKER_DEBUG` (not `DEBUG`) to avoid collision with the Anthropic SDK's own debug logger.

## Test plan

- [ ] `npm test` — all 59 tests pass
- [ ] `npm run check:debug` twice in a row — hash values in `debug.log` are identical between runs for all sites
- [ ] Confirm `debug.log` is gitignored

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)