### PR TITLE
feat: support Gmail label assignment via messages.insert

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ Tests live in `tests/` and mirror `src/`. Run with `npm test`.
 | `GMAIL_CLIENT_SECRET` | Gmail OAuth2 client secret |
 | `GMAIL_REFRESH_TOKEN` | Gmail OAuth2 refresh token |
 | `NOTIFY_EMAIL` | Recipient email address |
+| `GMAIL_LABEL_NAME` | (Optional) Gmail label name to apply via `messages.insert`. Only works when `NOTIFY_EMAIL` is the same account as the OAuth credentials (`GMAIL_USER`). Label is created automatically if it doesn't exist. |
 | `DRY_RUN` | Set to `true` to skip email and state writes |
 | `GH_TOKEN` | GitHub token for creating issues on failures |
 

--- a/src/email.ts
+++ b/src/email.ts
@@ -65,6 +65,26 @@ export function buildEmailRaw(params: {
 }
 
 /**
+ * Looks up a Gmail label by name. If it doesn't exist, creates it and returns the new ID.
+ * Uses the Gmail API labels.list + labels.create endpoints.
+ */
+async function getOrCreateLabel(
+  gmail: ReturnType<typeof google.gmail>,
+  name: string
+): Promise<string> {
+  const { data } = await gmail.users.labels.list({ userId: "me" });
+  const existing = (data.labels ?? []).find((l) => l.name === name);
+  if (existing?.id) return existing.id;
+
+  const { data: created } = await gmail.users.labels.create({
+    userId: "me",
+    requestBody: { name },
+  });
+  if (!created.id) throw new Error(`Failed to create Gmail label "${name}"`);
+  return created.id;
+}
+
+/**
  * Digest email that aggregates all finding types into a single send.
  * Sending one email per run (rather than one per finding) is intentional:
  * it avoids inbox flooding when multiple sources become relevant simultaneously.
@@ -165,10 +185,19 @@ export async function sendEmail(
     html,
   });
 
-  await gmail.users.messages.send({
-    userId: "me",
-    requestBody: { raw },
-  });
-
-  console.log(`✉️  Email sent to ${notifyEmail}`);
+  const labelName = process.env.GMAIL_LABEL_NAME;
+  if (labelName) {
+    const labelId = await getOrCreateLabel(gmail, labelName);
+    await gmail.users.messages.insert({
+      userId: "me",
+      requestBody: { raw, labelIds: [labelId, "INBOX"] },
+    });
+    console.log(`✉️  Email inserted into mailbox with label "${labelName}" for ${notifyEmail}`);
+  } else {
+    await gmail.users.messages.send({
+      userId: "me",
+      requestBody: { raw },
+    });
+    console.log(`✉️  Email sent to ${notifyEmail}`);
+  }
 }


### PR DESCRIPTION
When GMAIL_LABEL_NAME env var is set, sendEmail switches from
messages.send to messages.insert, injecting the message directly
into the mailbox with the specified label (plus INBOX) applied.
The getOrCreateLabel helper looks up the label by name and creates
it automatically if absent.

Requires NOTIFY_EMAIL to be the same account as the OAuth
credentials (GMAIL_USER) since insert bypasses SMTP delivery.

https://claude.ai/code/session_014SU7whzcXM9XPunjrrkcJ4