### PR TITLE
chore: set module to Node16 to match moduleResolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
+    "module": "Node16",
     "moduleResolution": "node16",
     "esModuleInterop": true,
     "strict": false,


### PR DESCRIPTION
## Summary
- Aligns `module` compiler option with `moduleResolution: node16` in `tsconfig.json`
- Previously `module: CommonJS` was inconsistent with `moduleResolution: node16`

## Test plan
- [ ] Verify TypeScript compilation succeeds with `npx tsc --noEmit`
- [ ] Run `npm test` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)