### PR TITLE
test: add timeout validation tests + fix Puppeteer 60s timeout

### DIFF
--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -75,7 +75,7 @@ export async function fetchWithPuppeteer(url: string): Promise<string> {
     await page.setUserAgent(
       "Mozilla/5.0 (compatible; AuditionChecker/1.0; +https://github.com)"
     );
-    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30000 });
+    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 60000 });
     // Wait a bit more for lazy-loaded content
     await new Promise((r) => setTimeout(r, 2000));
     return await page.content();

--- a/tests/scraper-network.test.ts
+++ b/tests/scraper-network.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for network timeout configuration in scraper.ts.
+ * These guard against accidentally reducing timeouts that caused real CI failures
+ * (e.g., Playbill's JS-rendered SPA timing out in GitHub Actions).
+ */
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+// vi.hoisted ensures these refs are available inside the vi.mock() factories,
+// which are hoisted to the top of the file before any imports.
+const { mockGoto, mockContent, mockNewPage, mockBrowserClose, mockLaunch } =
+  vi.hoisted(() => ({
+    mockGoto: vi.fn(),
+    mockContent: vi.fn(),
+    mockNewPage: vi.fn(),
+    mockBrowserClose: vi.fn(),
+    mockLaunch: vi.fn(),
+  }));
+
+vi.mock("puppeteer", () => ({
+  default: { launch: mockLaunch },
+}));
+
+vi.mock("https", () => ({
+  get: vi.fn(),
+}));
+
+import * as https from "https";
+import { fetchPage, fetchWithPuppeteer } from "../src/scraper";
+
+// ─── fetchPage ────────────────────────────────────────────────────────────────
+
+describe("fetchPage", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("rejects with 'Request timed out' when the request stalls", async () => {
+    let capturedTimeoutMs: number | undefined;
+    const mockReq = {
+      on: vi.fn(),
+      destroy: vi.fn(),
+      setTimeout: vi.fn().mockImplementation((ms: number, cb: () => void) => {
+        capturedTimeoutMs = ms;
+        cb(); // trigger immediately to simulate a stalled request
+      }),
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(https.get).mockImplementation(() => mockReq as any);
+
+    await expect(fetchPage("https://example.com")).rejects.toThrow(
+      "Request timed out"
+    );
+    expect(mockReq.destroy).toHaveBeenCalled();
+    expect(capturedTimeoutMs).toBe(15000);
+  });
+});
+
+// ─── fetchWithPuppeteer ───────────────────────────────────────────────────────
+
+describe("fetchWithPuppeteer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockGoto.mockResolvedValue(undefined);
+    mockContent.mockResolvedValue("<html><body>loaded page content</body></html>");
+    mockNewPage.mockResolvedValue({
+      setUserAgent: vi.fn().mockResolvedValue(undefined),
+      goto: mockGoto,
+      content: mockContent,
+    });
+    mockBrowserClose.mockResolvedValue(undefined);
+    mockLaunch.mockResolvedValue({
+      newPage: mockNewPage,
+      close: mockBrowserClose,
+    });
+  });
+
+  it("uses a 60-second navigation timeout", async () => {
+    await fetchWithPuppeteer("https://playbill.com/jobs");
+
+    expect(mockGoto).toHaveBeenCalledWith(
+      "https://playbill.com/jobs",
+      expect.objectContaining({ timeout: 60000 })
+    );
+  });
+
+  it("always closes the browser, even on error", async () => {
+    mockGoto.mockRejectedValue(new Error("Navigation timeout"));
+
+    await expect(
+      fetchWithPuppeteer("https://example.com")
+    ).rejects.toThrow("Navigation timeout");
+
+    expect(mockBrowserClose).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds unit tests in `tests/scraper-network.test.ts` to guard against timeout regressions in `fetchPage` and `fetchWithPuppeteer`. Also applies the 30s→60s Puppeteer navigation timeout fix from the sibling branch.

The existing `test.yml` workflow runs `npm test` on every PR, so these tests are automatically picked up in CI without any workflow changes.

Fixes #17

Generated with [Claude Code](https://claude.ai/code)