### PR TITLE
fix: fall back to gemini-2.0-flash on 503 overload

### DIFF
--- a/audition-state.json
+++ b/audition-state.json
@@ -1,5 +1,5 @@
 {
-  "lastRun": "2026-04-13T08:51:43.080Z",
+  "lastRun": "2026-04-14T04:18:07.773Z",
   "pages": {
     "https://www.chamberorchestraofthetriangle.org/employment": {
       "url": "https://www.chamberorchestraofthetriangle.org/employment",
@@ -24,10 +24,10 @@
     "https://www.fayettevillesymphony.org/auditions-and-employment/": {
       "url": "https://www.fayettevillesymphony.org/auditions-and-employment/",
       "name": "Fayetteville Symphony Orchestra",
-      "lastChecked": "2026-04-13T08:51:33.955Z",
-      "contentHash": "b384de6ac0b76860",
-      "extractedSummary": "While there are no active audition submissions at this time, the Fayetteville Symphony Orchestra is accepting inquiries for its sub list. This is relevant as a sub list is open to various instruments, including trumpet, and could lead to future performance opportunities.",
-      "hasRelevantAuditions": true,
+      "lastChecked": "2026-04-14T04:18:01.279Z",
+      "contentHash": "2f8f29837ff837a4",
+      "extractedSummary": null,
+      "hasRelevantAuditions": false,
       "notifiedRelevantItems": [
         "substitute list"
       ]
@@ -132,7 +132,7 @@
       "notifiedRelevantItems": []
     }
   },
-  "playbillIndexHash": "198fef8346323015",
+  "playbillIndexHash": "d6f12d188ef61eb1",
   "playbillListings": {
     "https://playbill.com/job/mrs-doubtfire-national-tour-drums-percussion/a0380083-fa6a-4e35-9549-bb35933d6694": {
       "url": "https://playbill.com/job/mrs-doubtfire-national-tour-drums-percussion/a0380083-fa6a-4e35-9549-bb35933d6694",
@@ -398,6 +398,17 @@
       "notified": true,
       "summary": null,
       "contentHash": "05fe63520b5d0110"
+    },
+    "https://playbill.com/job/seeking-musicians-keyboard-fiddle-guitar-pedal-steel-guitar-drums-for-honky-tonk-angels/17e92b84-616d-47cd-be9b-8ec4e5af5d91": {
+      "url": "https://playbill.com/job/seeking-musicians-keyboard-fiddle-guitar-pedal-steel-guitar-drums-for-honky-tonk-angels/17e92b84-616d-47cd-be9b-8ec4e5af5d91",
+      "title": "Seeking Musicians: Keyboard, Fiddle/Guitar, Pedal Steel Guitar, Drums for Honky Tonk Angels",
+      "organization": "Florida Studio Theatre",
+      "firstSeen": "2026-04-14T04:18:01.281Z",
+      "lastChecked": "2026-04-14T04:18:01.281Z",
+      "hasTrumpet": false,
+      "notified": true,
+      "summary": null,
+      "contentHash": "5f6d6cd84d1e8448"
     }
   }
 }

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -39,55 +39,76 @@ function isDailyQuotaExhausted(errorDetails?: { [key: string]: unknown }[]): boo
 }
 
 const DEFAULT_MODEL = "gemini-2.5-flash";
+const FALLBACK_MODEL = "gemini-2.0-flash";
 
 /** Creates a Gemini-backed LlmClient. */
 export function createGeminiClient(apiKey: string, modelName?: string): LlmClient {
   const genAI = new GoogleGenerativeAI(apiKey);
-  const model = genAI.getGenerativeModel({ model: modelName || DEFAULT_MODEL });
+  const primaryName = modelName || DEFAULT_MODEL;
+  const fallbackName = primaryName !== FALLBACK_MODEL ? FALLBACK_MODEL : null;
 
   return {
     async generate(prompt: string, maxTokens: number): Promise<string> {
-      for (let attempt = 0; ; attempt++) {
-        try {
-          // thinkingConfig is supported by the REST API inside generationConfig
-          // but not typed in @google/generative-ai v0.24 — the SDK passes the
-          // object through to the API via JSON.stringify, so the cast is safe.
-          const result = await model.generateContent({
-            contents: [{ role: "user", parts: [{ text: prompt }] }],
-            generationConfig: {
-              maxOutputTokens: maxTokens,
-              temperature: 0,
-              responseMimeType: "application/json",
-              thinkingConfig: { thinkingBudget: 0 },
-            } as Parameters<typeof model.generateContent>[0] extends { generationConfig?: infer G } ? G : never,
-          });
-          const usage = result.response.usageMetadata;
-          if (usage) {
-            console.log(
-              `  [tokens] in=${usage.promptTokenCount ?? 0} out=${usage.candidatesTokenCount ?? 0} total=${usage.totalTokenCount ?? 0}`
-            );
-          }
-          return result.response.text();
-        } catch (err) {
-          if (
-            err instanceof GoogleGenerativeAIFetchError &&
-            err.status === 429
-          ) {
-            if (isDailyQuotaExhausted(err.errorDetails)) {
-              throw new DailyQuotaExhaustedError();
-            }
-            if (attempt < MAX_RETRIES) {
-              const retryMs = parseRetryDelay(err.errorDetails) || BASE_DELAY_MS * 2 ** attempt;
+      const modelsToTry = [primaryName, ...(fallbackName ? [fallbackName] : [])];
+
+      for (let m = 0; m < modelsToTry.length; m++) {
+        const currentName = modelsToTry[m];
+        const model = genAI.getGenerativeModel({ model: currentName });
+        const hasNext = m < modelsToTry.length - 1;
+
+        for (let attempt = 0; ; attempt++) {
+          try {
+            // thinkingConfig is supported by the REST API inside generationConfig
+            // but not typed in @google/generative-ai v0.24 — the SDK passes the
+            // object through to the API via JSON.stringify, so the cast is safe.
+            const result = await model.generateContent({
+              contents: [{ role: "user", parts: [{ text: prompt }] }],
+              generationConfig: {
+                maxOutputTokens: maxTokens,
+                temperature: 0,
+                responseMimeType: "application/json",
+                thinkingConfig: { thinkingBudget: 0 },
+              } as Parameters<typeof model.generateContent>[0] extends { generationConfig?: infer G } ? G : never,
+            });
+            const usage = result.response.usageMetadata;
+            if (usage) {
               console.log(
-                `  \u23F3 Gemini 429 \u2014 retry ${attempt + 1}/${MAX_RETRIES} in ${Math.round(retryMs / 1000)}s...`
+                `  [tokens] in=${usage.promptTokenCount ?? 0} out=${usage.candidatesTokenCount ?? 0} total=${usage.totalTokenCount ?? 0}`
               );
-              await new Promise((r) => setTimeout(r, retryMs));
-              continue;
             }
+            return result.response.text();
+          } catch (err) {
+            if (
+              err instanceof GoogleGenerativeAIFetchError &&
+              err.status === 429
+            ) {
+              if (isDailyQuotaExhausted(err.errorDetails)) {
+                throw new DailyQuotaExhaustedError();
+              }
+              if (attempt < MAX_RETRIES) {
+                const retryMs = parseRetryDelay(err.errorDetails) || BASE_DELAY_MS * 2 ** attempt;
+                console.log(
+                  `  \u23F3 Gemini 429 \u2014 retry ${attempt + 1}/${MAX_RETRIES} in ${Math.round(retryMs / 1000)}s...`
+                );
+                await new Promise((r) => setTimeout(r, retryMs));
+                continue;
+              }
+            }
+            if (
+              err instanceof GoogleGenerativeAIFetchError &&
+              err.status === 503 &&
+              hasNext
+            ) {
+              console.log(
+                `  \u26A0\uFE0F ${currentName} overloaded (503) \u2014 falling back to ${modelsToTry[m + 1]}...`
+              );
+              break;
+            }
+            throw err;
           }
-          throw err;
         }
       }
+      throw new Error("All Gemini models unavailable");
     },
   };
 }

--- a/tests/llm.test.ts
+++ b/tests/llm.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GoogleGenerativeAIFetchError } from "@google/generative-ai";
+import { createGeminiClient, DailyQuotaExhaustedError } from "../src/llm.ts";
+
+// Mock the @google/generative-ai module while keeping the real error classes
+const mockGenerateContent = vi.fn();
+
+vi.mock("@google/generative-ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@google/generative-ai")>();
+
+  return {
+    ...actual,
+    GoogleGenerativeAI: class {
+      getGenerativeModel() {
+        return { generateContent: mockGenerateContent };
+      }
+    },
+  };
+});
+
+function makeResponse(text: string) {
+  return {
+    response: {
+      text: () => text,
+      usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
+    },
+  };
+}
+
+describe("createGeminiClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns response text on success", async () => {
+    mockGenerateContent.mockResolvedValueOnce(makeResponse('{"ok":true}'));
+
+    const client = createGeminiClient("fake-key");
+    const result = await client.generate("test prompt", 100);
+
+    expect(result).toBe('{"ok":true}');
+  });
+
+  it("falls back to another model on 503", async () => {
+    mockGenerateContent
+      .mockRejectedValueOnce(new GoogleGenerativeAIFetchError("overloaded", 503))
+      .mockResolvedValueOnce(makeResponse('{"fallback":true}'));
+
+    const client = createGeminiClient("fake-key");
+    const result = await client.generate("test prompt", 100);
+
+    expect(result).toBe('{"fallback":true}');
+    expect(mockGenerateContent).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws 503 when primary is already the fallback model (no fallback available)", async () => {
+    mockGenerateContent.mockRejectedValueOnce(
+      new GoogleGenerativeAIFetchError("overloaded", 503)
+    );
+
+    const client = createGeminiClient("fake-key", "gemini-2.0-flash");
+    await expect(client.generate("test prompt", 100)).rejects.toThrow(
+      GoogleGenerativeAIFetchError
+    );
+  });
+
+  it("throws 503 when both primary and fallback are overloaded", async () => {
+    mockGenerateContent
+      .mockRejectedValueOnce(new GoogleGenerativeAIFetchError("overloaded", 503))
+      .mockRejectedValueOnce(new GoogleGenerativeAIFetchError("still overloaded", 503));
+
+    const client = createGeminiClient("fake-key");
+    await expect(client.generate("test prompt", 100)).rejects.toThrow(
+      GoogleGenerativeAIFetchError
+    );
+    expect(mockGenerateContent).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries 429 with backoff (does not fall back to different model)", async () => {
+    vi.useFakeTimers();
+
+    mockGenerateContent
+      .mockRejectedValueOnce(new GoogleGenerativeAIFetchError("rate limited", 429))
+      .mockResolvedValueOnce(makeResponse('{"retried":true}'));
+
+    const client = createGeminiClient("fake-key");
+    const resultPromise = client.generate("test prompt", 100);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    const result = await resultPromise;
+    expect(result).toBe('{"retried":true}');
+    expect(mockGenerateContent).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
+  it("throws DailyQuotaExhaustedError on daily quota 429", async () => {
+    mockGenerateContent.mockRejectedValueOnce(
+      new GoogleGenerativeAIFetchError("quota", 429, "Too Many Requests", [
+        {
+          "@type": "type.googleapis.com/google.rpc.QuotaFailure",
+          violations: [{ quotaId: "GenerateRequestsPerDayPerProjectPerModel" }],
+        },
+      ])
+    );
+
+    const client = createGeminiClient("fake-key");
+    await expect(client.generate("test prompt", 100)).rejects.toThrow(
+      DailyQuotaExhaustedError
+    );
+  });
+
+  it("throws non-retryable errors immediately", async () => {
+    mockGenerateContent.mockRejectedValueOnce(new Error("network failure"));
+
+    const client = createGeminiClient("fake-key");
+    await expect(client.generate("test prompt", 100)).rejects.toThrow("network failure");
+    expect(mockGenerateContent).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- When `gemini-2.5-flash` returns a 503 (model overloaded / high demand), the LLM client now immediately falls back to `gemini-2.0-flash` instead of throwing
- This prevents missed Playbill listing extractions during traffic spikes (as seen in the April 13 run)
- Existing 429 retry-with-backoff behavior is unchanged

## Test plan
- [x] New `tests/llm.test.ts` covers: success, 503 fallback, both models down, 429 retry, daily quota, non-retryable errors
- [x] All 131 tests pass
- [ ] Trigger weekly checker workflow from this branch to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)