### PR TITLE
fix: stop LLM verdict flip-flop from re-triggering notifications

### DIFF
--- a/audition-state.json
+++ b/audition-state.json
@@ -1,5 +1,5 @@
 {
-  "lastRun": "2026-05-14T20:29:24.792Z",
+  "lastRun": "2026-05-14T22:10:37.046Z",
   "pages": {
     "https://www.chamberorchestraofthetriangle.org/employment": {
       "url": "https://www.chamberorchestraofthetriangle.org/employment",
@@ -105,9 +105,9 @@
     "https://www.charlottesymphony.org/about/employment-auditions/": {
       "url": "https://www.charlottesymphony.org/about/employment-auditions/",
       "name": "Charlotte Symphony",
-      "lastChecked": "2026-05-14T20:29:17.648Z",
-      "contentHash": "a7554dc2eb4be610",
-      "extractedSummary": "The Charlotte Symphony Orchestra is holding auditions for a Second Trumpet position. The application deadline is May 1, 2026, with auditions scheduled for May 31 - June 2, 2026. This is a full-time, tenure-track position with employment starting in September 2026.",
+      "lastChecked": "2026-05-14T22:10:31.573Z",
+      "contentHash": "2a8fbe663173171f",
+      "extractedSummary": "The Charlotte Symphony is holding auditions for a Second Trumpet position. The application deadline is May 1, 2026, with auditions scheduled for May 31 - June 2, 2026. The position is full-time, tenure track, with employment starting in September 2026.",
       "hasRelevantAuditions": true,
       "notifiedRelevantItems": [
         "second trumpet"
@@ -155,7 +155,7 @@
       ]
     }
   },
-  "playbillIndexHash": "5bb7a4938db8e44d",
+  "playbillIndexHash": "7de07e92576e2163",
   "playbillListings": {
     "https://playbill.com/job/mrs-doubtfire-national-tour-drums-percussion/a0380083-fa6a-4e35-9549-bb35933d6694": {
       "url": "https://playbill.com/job/mrs-doubtfire-national-tour-drums-percussion/a0380083-fa6a-4e35-9549-bb35933d6694",

--- a/src/check-auditions.ts
+++ b/src/check-auditions.ts
@@ -142,28 +142,27 @@ export function canonicalizeLabel(label: string): string {
 /**
  * Determines whether a standard page should trigger a new user notification.
  *
- * Fires on two conditions:
- *   1. Rising edge — page was not relevant before, is now.
- *   2. New relevant item — page was already relevant, but Claude returned at least
- *      one item not present when the user was last notified (e.g. a second trumpet
- *      audition was added). Non-trumpet content changes won't fire because Claude's
- *      `relevantItems` list will be unchanged.
+ * Fires when the page is relevant AND either (a) the user has never been
+ * notified about this page before, or (b) the LLM returned at least one
+ * canonical item not yet in `notifiedItems`.
  *
- * `notifiedItems` being empty means no notification was ever sent, which always
- * counts as "new" when the page is relevant.
+ * The previous rising-edge rule (notify whenever `wasRelevant` flipped false →
+ * true) was removed because the LLM's relevance verdict flip-flops on
+ * borderline content (e.g. "we accept sub-list emails"). Once we've already
+ * told the user about an opportunity, a later false → true flip with the same
+ * underlying items should not re-notify.
  *
- * `notifiedItems` are stored in canonical form (via `canonicalizeLabel`). Incoming
- * `currentItems` are canonicalized before comparison so wording variants of the
- * same opportunity are treated as already-seen.
+ * `notifiedItems` is stored in canonical form (via `canonicalizeLabel`).
+ * Incoming `currentItems` are canonicalized before comparison so wording
+ * variants of the same opportunity are treated as already-seen.
  */
 export function shouldNotify(
   isNowRelevant: boolean,
-  wasRelevant: boolean,
   currentItems: string[],
   notifiedItems: string[]
 ): boolean {
   if (!isNowRelevant) return false;
-  if (!wasRelevant) return true; // rising edge
+  if (notifiedItems.length === 0) return true; // first-ever notification for this page
   return currentItems.some((item) => !notifiedItems.includes(canonicalizeLabel(item)));
 }
 
@@ -257,7 +256,7 @@ export async function processStandardUrl(params: ProcessStandardUrlParams): Prom
     pageState.notifiedRelevantItems = [
       ...new Set(analysis.relevantItems.map(canonicalizeLabel)),
     ];
-  } else if (shouldNotify(analysis.hasRelevantAuditions, wasRelevant, analysis.relevantItems, notifiedItems)) {
+  } else if (shouldNotify(analysis.hasRelevantAuditions, analysis.relevantItems, notifiedItems)) {
     const instrumentLabel = analysis.instrument.join(", ") || "Relevant";
     console.log(`[NEW][AI-MATCH] ${urlConfig.name} — ${instrumentLabel}`);
     finding = {

--- a/tests/check-auditions.test.ts
+++ b/tests/check-auditions.test.ts
@@ -126,75 +126,60 @@ describe("buildEmailRaw", () => {
 
 describe("shouldNotify", () => {
   it("returns false when page is not relevant", () => {
-    expect(shouldNotify(false, false, [], [])).toBe(false);
-    expect(shouldNotify(false, true, ["Principal Trumpet"], ["Principal Trumpet"])).toBe(false);
+    expect(shouldNotify(false, [], [])).toBe(false);
+    expect(shouldNotify(false, ["Principal Trumpet"], ["principal trumpet"])).toBe(false);
   });
 
-  it("returns true on rising edge (false → true)", () => {
-    expect(shouldNotify(true, false, ["Principal Trumpet"], [])).toBe(true);
+  it("returns true on first-ever notification (notifiedItems empty)", () => {
+    expect(shouldNotify(true, ["Principal Trumpet"], [])).toBe(true);
   });
 
-  it("returns false when still relevant with same items (suppress re-notification)", () => {
+  it("returns false when relevant with same items (suppress re-notification)", () => {
     // notifiedItems holds canonical form as written by canonicalizeLabel at store time
-    expect(shouldNotify(true, true, ["Principal Trumpet"], ["principal trumpet"])).toBe(false);
+    expect(shouldNotify(true, ["Principal Trumpet"], ["principal trumpet"])).toBe(false);
   });
 
-  it("returns true when still relevant and a new trumpet item was added (bug fix case)", () => {
+  it("returns true when a new trumpet item was added alongside an already-notified one", () => {
     expect(
-      shouldNotify(true, true, ["Principal Trumpet", "Second Trumpet"], ["principal trumpet"])
+      shouldNotify(true, ["Principal Trumpet", "Second Trumpet"], ["principal trumpet"])
     ).toBe(true);
   });
 
-  it("returns false when still relevant but only non-trumpet content changed (same relevant items)", () => {
-    // Claude re-analyzed after a non-trumpet audition was added, but relevantItems is unchanged
-    expect(shouldNotify(true, true, ["Principal Trumpet"], ["principal trumpet"])).toBe(false);
-  });
-
-  it("returns true when still relevant but notifiedItems is empty (never notified before)", () => {
-    expect(shouldNotify(true, true, ["Principal Trumpet"], [])).toBe(true);
-  });
-
-  it("returns true on rising edge when notifiedItems is empty (new page, first notification)", () => {
-    expect(shouldNotify(true, false, ["Principal Trumpet"], [])).toBe(true);
+  // Regression: the LLM flip-flopped hasRelevantAuditions on the Fayetteville sub-list page
+  // for weeks, causing a fresh "rising edge" email every time it flipped back to true.
+  // With notifiedItems already containing the canonical, the flip must not re-notify.
+  it("does not re-notify when LLM verdict flips false → true with the same canonical item", () => {
+    expect(shouldNotify(true, ["Sub list for all instruments"], ["substitute list"])).toBe(false);
   });
 
   // Canonical label matching: all wording variants of the same opportunity share
   // one canonical string, so no wording change can trigger a spurious re-notification.
-  it("does not re-notify when Claude uses a different phrasing for the same sub-list opportunity", () => {
-    // Stored canonical: "substitute list" (written by canonicalizeLabel on first notify)
-    // Claude returns a wording variant on the next run — all should canonicalize to "substitute list"
+  it("does not re-notify when LLM uses a different phrasing for the same sub-list opportunity", () => {
     const storedCanonical = ["substitute list"];
-    expect(shouldNotify(true, true, ["Sub list for all instruments"], storedCanonical)).toBe(false);
-    expect(shouldNotify(true, true, ["Substitute musician positions"], storedCanonical)).toBe(false);
+    expect(shouldNotify(true, ["Sub list for all instruments"], storedCanonical)).toBe(false);
+    expect(shouldNotify(true, ["Substitute musician positions"], storedCanonical)).toBe(false);
     expect(
       shouldNotify(
-        true,
         true,
         ["Sub list for all instruments (contact operations manager)"],
         storedCanonical
       )
     ).toBe(false);
     expect(
-      shouldNotify(
-        true,
-        true,
-        ["Substitute musician positions - general orchestral"],
-        storedCanonical
-      )
+      shouldNotify(true, ["Substitute musician positions - general orchestral"], storedCanonical)
     ).toBe(false);
   });
 
   it("still notifies when a genuinely new item appears alongside an already-notified canonical", () => {
-    // Sub list was previously notified; a new Principal Trumpet position just appeared.
     expect(
-      shouldNotify(true, true, ["Substitute musician positions", "Principal Trumpet"], [
+      shouldNotify(true, ["Substitute musician positions", "Principal Trumpet"], [
         "substitute list",
       ])
     ).toBe(true);
   });
 
   it("still notifies for a genuinely different canonical category", () => {
-    expect(shouldNotify(true, true, ["Principal Trumpet"], ["substitute list"])).toBe(true);
+    expect(shouldNotify(true, ["Principal Trumpet"], ["substitute list"])).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- Fixes spurious re-notifications (e.g. Fayetteville Symphony) caused by Gemini flip-flopping `hasRelevantAuditions` between `false` and `true` on unchanged sub-list pages.
- `shouldNotify` previously treated any `false → true` transition as a "rising edge" and emailed unconditionally, ignoring `notifiedRelevantItems`. The rising-edge branch now consults `notifiedItems` too, so re-notification only fires when at least one canonical item is genuinely new (or the page has never been notified before).
- Dropped the now-unused `wasRelevant` parameter from `shouldNotify` and updated the call site and tests accordingly.

## Background

Reviewing the state-file history for `https://www.fayettevillesymphony.org/auditions-and-employment/` showed the LLM verdict flipping repeatedly on essentially identical content:

| date | hash | relevant |
|---|---|---|
| 2026-04-04 | `d726a970…` | false |
| 2026-04-13 | `b384de6a…` | **true** ← email |
| 2026-04-14 | `2f8f2983…` | false |
| 2026-05-04 | `79b278cb…` | **true** ← email |
| 2026-05-08 | `5becd91a…` | false |
| 2026-05-14 | `ede7e9e5…` | **true** ← email |

`notifiedRelevantItems` already contained `"substitute list"` throughout, but the old rising-edge rule never consulted it. After this fix, those `false → true` flips with the same canonical item will not re-notify.

Note: the `contentHash` is also unstable across runs (likely a rotating non-audition block surviving `extractAuditionSignals`), so the LLM is still being called weekly for Fayetteville. That's a separate follow-up — this PR only stops the spurious emails.

## Test plan

- [x] `npm test` — all 129 tests pass
- [x] New regression test: `shouldNotify(true, ["Sub list for all instruments"], ["substitute list"]) === false`
- [x] Existing wording-variant suppression tests still pass under the new signature
- [ ] Next scheduled cron run (Monday) produces no Fayetteville email if state is unchanged

https://claude.ai/code/session_01JeuGrWrvPfvr5xsTD6UW8i

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeuGrWrvPfvr5xsTD6UW8i)_