### PR TITLE
fix: harden Gmail OAuth2 token exchange against node-fetch "Premature close"

### DIFF
--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -1,5 +1,6 @@
+import * as https from "https";
+
 import { LlmClient, DailyQuotaExhaustedError } from "./llm";
-import { google } from "googleapis";
 
 import { MIN_CONTENT_LENGTH, fetchPage, fetchWithFirecrawl, stripHtml, extractMainContent } from "./scraper";
 import { UrlConfig, ProbeFailure } from "./email";
@@ -23,6 +24,71 @@ function isPermanentOAuthError(err: unknown): boolean {
     msg.includes("invalid_client") ||
     msg.includes("unauthorized_client")
   );
+}
+
+/**
+ * Exchanges the refresh token for an access token via a direct POST to Google's OAuth
+ * endpoint using Node's native `https` module.
+ *
+ * We deliberately bypass the `googleapis`/`gaxios` client here: gaxios v6 performs its
+ * fetch through node-fetch v2, which throws "Invalid response body ... Premature close"
+ * when the keep-alive connection to `oauth2.googleapis.com` is closed early on recent
+ * Node runtimes — the exact failure that was aborting the weekly run every time. Native
+ * `https` (already the project's preferred HTTP mechanism, see scraper.ts) is not subject
+ * to that node-fetch bug. A genuine credential rejection still comes back as a 400 with an
+ * `invalid_grant` body, which `isPermanentOAuthError` detects so we fail fast.
+ */
+function exchangeRefreshTokenForAccessToken(): Promise<string> {
+  const body = new URLSearchParams({
+    client_id: process.env.GMAIL_CLIENT_ID!,
+    client_secret: process.env.GMAIL_CLIENT_SECRET!,
+    refresh_token: process.env.GMAIL_REFRESH_TOKEN!,
+    grant_type: "refresh_token",
+  }).toString();
+
+  return new Promise<string>((resolve, reject) => {
+    const req = https.request(
+      {
+        hostname: "oauth2.googleapis.com",
+        path: "/token",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Content-Length": Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          let parsed: { access_token?: string; error?: string; error_description?: string };
+          try {
+            parsed = JSON.parse(data);
+          } catch {
+            reject(new Error(`Unexpected token endpoint response (${res.statusCode}): ${data}`));
+            return;
+          }
+          if (res.statusCode === 200 && parsed.access_token) {
+            resolve(parsed.access_token);
+          } else {
+            // Surface Google's `error` (e.g. invalid_grant) so isPermanentOAuthError can classify it.
+            reject(
+              new Error(
+                `${parsed.error ?? `HTTP ${res.statusCode}`}${parsed.error_description ? `: ${parsed.error_description}` : ""}`
+              )
+            );
+          }
+        });
+      }
+    );
+    req.on("error", reject);
+    req.setTimeout(15000, () => {
+      req.destroy();
+      reject(new Error("Token request timed out"));
+    });
+    req.write(body);
+    req.end();
+  });
 }
 
 /**
@@ -56,16 +122,10 @@ export async function preflightSecrets(): Promise<void> {
   }
   console.log("  ✓ All required env vars present");
 
-  // Verify OAuth2 token exchange actually works
-  const oauth2Client = new google.auth.OAuth2(
-    process.env.GMAIL_CLIENT_ID,
-    process.env.GMAIL_CLIENT_SECRET
-  );
-  oauth2Client.setCredentials({ refresh_token: process.env.GMAIL_REFRESH_TOKEN });
-
+  // Verify OAuth2 token exchange actually works (native https — see helper for rationale)
   for (let attempt = 0; attempt <= OAUTH_MAX_RETRIES; attempt++) {
     try {
-      const { token } = await oauth2Client.getAccessToken();
+      const token = await exchangeRefreshTokenForAccessToken();
       if (!token) throw new Error("Empty access token returned");
       console.log("  ✓ Gmail OAuth2 token exchange successful");
       return;

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -7,11 +7,34 @@ import { probeIsAuditionPage } from "./llm-classifiers";
 
 // ─── Preflight: secrets ───────────────────────────────────────────────────────
 
+const OAUTH_MAX_RETRIES = 3;
+const OAUTH_BASE_DELAY_MS = 2000;
+
+/**
+ * A permanent OAuth2 failure (bad/expired/revoked credentials) is not worth retrying —
+ * Google surfaces these as `invalid_grant`/`invalid_client`/`unauthorized_client`. Every
+ * other failure (e.g. "Premature close", ECONNRESET, socket hang up, timeouts) is a
+ * transient transport error where the credentials never got judged, so a retry can succeed.
+ */
+function isPermanentOAuthError(err: unknown): boolean {
+  const msg = String(err instanceof Error ? err.message : err).toLowerCase();
+  return (
+    msg.includes("invalid_grant") ||
+    msg.includes("invalid_client") ||
+    msg.includes("unauthorized_client")
+  );
+}
+
 /**
  * Validates not just presence but actual usability of credentials by performing a
  * live OAuth2 token exchange. This catches expired refresh tokens before any page
  * fetching or state mutation occurs, so a credential failure produces a clean error
  * rather than a partially-completed run with no email sent.
+ *
+ * The token exchange is retried with exponential backoff because the request to
+ * Google's OAuth endpoint occasionally drops mid-flight (e.g. "Premature close") on
+ * CI runners — a transport hiccup that should not abort the entire weekly run. Genuine
+ * credential rejections fail fast without retrying.
  */
 export async function preflightSecrets(): Promise<void> {
   console.log("🔐 Preflight: checking secrets...");
@@ -40,12 +63,22 @@ export async function preflightSecrets(): Promise<void> {
   );
   oauth2Client.setCredentials({ refresh_token: process.env.GMAIL_REFRESH_TOKEN });
 
-  try {
-    const { token } = await oauth2Client.getAccessToken();
-    if (!token) throw new Error("Empty access token returned");
-    console.log("  ✓ Gmail OAuth2 token exchange successful");
-  } catch (err) {
-    throw new Error(`Gmail OAuth2 token exchange failed: ${err}`);
+  for (let attempt = 0; attempt <= OAUTH_MAX_RETRIES; attempt++) {
+    try {
+      const { token } = await oauth2Client.getAccessToken();
+      if (!token) throw new Error("Empty access token returned");
+      console.log("  ✓ Gmail OAuth2 token exchange successful");
+      return;
+    } catch (err) {
+      if (isPermanentOAuthError(err) || attempt === OAUTH_MAX_RETRIES) {
+        throw new Error(`Gmail OAuth2 token exchange failed: ${err}`);
+      }
+      const delayMs = OAUTH_BASE_DELAY_MS * 2 ** attempt;
+      console.log(
+        `  ⏳ Gmail OAuth2 token exchange failed (${err}) — retry ${attempt + 1}/${OAUTH_MAX_RETRIES} in ${Math.round(delayMs / 1000)}s...`
+      );
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
   }
 }
 

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the OAuth2 token-exchange retry logic in preflightSecrets.
+ * Transient transport failures (e.g. "Premature close") should be retried with
+ * backoff, while genuine credential rejections (invalid_grant) fail fast.
+ */
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+
+const getAccessToken = vi.fn();
+const setCredentials = vi.fn();
+
+vi.mock("googleapis", () => ({
+  google: {
+    auth: {
+      OAuth2: class {
+        setCredentials = setCredentials;
+        getAccessToken = getAccessToken;
+      },
+    },
+  },
+}));
+
+import { preflightSecrets } from "../src/preflight";
+
+const REQUIRED_ENV = {
+  GEMINI_API_KEY: "g",
+  GMAIL_CLIENT_ID: "id",
+  GMAIL_CLIENT_SECRET: "secret",
+  GMAIL_REFRESH_TOKEN: "refresh",
+  GMAIL_USER: "user@example.com",
+};
+
+describe("preflightSecrets — OAuth2 token exchange retry", () => {
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(process.env, REQUIRED_ENV);
+    // Make backoff sleeps instant so the suite doesn't wait real seconds.
+    vi.spyOn(global, "setTimeout").mockImplementation((cb: () => void) => {
+      cb();
+      return 0 as unknown as NodeJS.Timeout;
+    });
+  });
+
+  afterEach(() => {
+    process.env = { ...savedEnv };
+    vi.restoreAllMocks();
+  });
+
+  it("throws when a required env var is missing", async () => {
+    delete process.env.GMAIL_REFRESH_TOKEN;
+    await expect(preflightSecrets()).rejects.toThrow(
+      /Missing required env vars: GMAIL_REFRESH_TOKEN/
+    );
+    expect(getAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("succeeds on the first attempt when the token exchange works", async () => {
+    getAccessToken.mockResolvedValue({ token: "abc" });
+    await expect(preflightSecrets()).resolves.toBeUndefined();
+    expect(getAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a transient 'Premature close' failure and then succeeds", async () => {
+    getAccessToken
+      .mockRejectedValueOnce(new Error("Premature close"))
+      .mockRejectedValueOnce(new Error("Premature close"))
+      .mockResolvedValue({ token: "abc" });
+
+    await expect(preflightSecrets()).resolves.toBeUndefined();
+    expect(getAccessToken).toHaveBeenCalledTimes(3);
+  });
+
+  it("gives up after exhausting retries on persistent transient failures", async () => {
+    getAccessToken.mockRejectedValue(new Error("Premature close"));
+
+    await expect(preflightSecrets()).rejects.toThrow(
+      /Gmail OAuth2 token exchange failed: Error: Premature close/
+    );
+    // Initial attempt + OAUTH_MAX_RETRIES (3) = 4 total calls.
+    expect(getAccessToken).toHaveBeenCalledTimes(4);
+  });
+
+  it("does NOT retry a permanent credential error (invalid_grant)", async () => {
+    getAccessToken.mockRejectedValue(new Error("invalid_grant"));
+
+    await expect(preflightSecrets()).rejects.toThrow(
+      /Gmail OAuth2 token exchange failed: Error: invalid_grant/
+    );
+    expect(getAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats an empty token as a failure and retries", async () => {
+    getAccessToken
+      .mockResolvedValueOnce({ token: null })
+      .mockResolvedValue({ token: "abc" });
+
+    await expect(preflightSecrets()).resolves.toBeUndefined();
+    expect(getAccessToken).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1,24 +1,18 @@
 /**
  * Tests for the OAuth2 token-exchange retry logic in preflightSecrets.
- * Transient transport failures (e.g. "Premature close") should be retried with
- * backoff, while genuine credential rejections (invalid_grant) fail fast.
+ *
+ * The token exchange is performed with Node's native `https` module (bypassing the
+ * googleapis/node-fetch "Premature close" bug). These tests drive that path via a
+ * scriptable `https.request` mock: transient transport failures should be retried
+ * with backoff, while genuine credential rejections (invalid_grant) fail fast.
  */
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 
-const getAccessToken = vi.fn();
-const setCredentials = vi.fn();
-
-vi.mock("googleapis", () => ({
-  google: {
-    auth: {
-      OAuth2: class {
-        setCredentials = setCredentials;
-        getAccessToken = getAccessToken;
-      },
-    },
-  },
+vi.mock("https", () => ({
+  request: vi.fn(),
 }));
 
+import * as https from "https";
 import { preflightSecrets } from "../src/preflight";
 
 const REQUIRED_ENV = {
@@ -29,6 +23,56 @@ const REQUIRED_ENV = {
   GMAIL_USER: "user@example.com",
 };
 
+type Outcome =
+  | { status: number; body: unknown }
+  | { networkError: string }
+  | { timeout: true };
+
+/**
+ * Queue a sequence of outcomes for successive https.request calls. Each entry maps to
+ * one token-exchange attempt, letting a single test assert the retry sequence.
+ */
+function queueHttps(outcomes: Outcome[]): void {
+  let i = 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  vi.mocked(https.request).mockImplementation(((_opts: any, cb: (res: any) => void) => {
+    const outcome = outcomes[i++] ?? { status: 200, body: { access_token: "abc" } };
+    let errorHandler: ((e: Error) => void) | undefined;
+    const req = {
+      on: (evt: string, h: (e: Error) => void) => {
+        if (evt === "error") errorHandler = h;
+        return req;
+      },
+      setTimeout: (_ms: number, h: () => void) => {
+        if ("timeout" in outcome) queueMicrotask(() => h());
+        return req;
+      },
+      write: () => req,
+      end: () => req,
+      destroy: () => req,
+    };
+    queueMicrotask(() => {
+      if ("networkError" in outcome) {
+        errorHandler?.(new Error(outcome.networkError));
+      } else if ("status" in outcome) {
+        const resHandlers: Record<string, (arg?: string) => void> = {};
+        const res = {
+          statusCode: outcome.status,
+          on: (evt: string, h: (arg?: string) => void) => {
+            resHandlers[evt] = h;
+            return res;
+          },
+        };
+        cb(res);
+        resHandlers.data?.(JSON.stringify(outcome.body));
+        resHandlers.end?.();
+      }
+    });
+    return req;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any);
+}
+
 describe("preflightSecrets — OAuth2 token exchange retry", () => {
   const savedEnv = { ...process.env };
 
@@ -36,10 +80,11 @@ describe("preflightSecrets — OAuth2 token exchange retry", () => {
     vi.clearAllMocks();
     Object.assign(process.env, REQUIRED_ENV);
     // Make backoff sleeps instant so the suite doesn't wait real seconds.
-    vi.spyOn(global, "setTimeout").mockImplementation((cb: () => void) => {
+    vi.spyOn(global, "setTimeout").mockImplementation(((cb: () => void) => {
       cb();
       return 0 as unknown as NodeJS.Timeout;
-    });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any);
   });
 
   afterEach(() => {
@@ -52,50 +97,58 @@ describe("preflightSecrets — OAuth2 token exchange retry", () => {
     await expect(preflightSecrets()).rejects.toThrow(
       /Missing required env vars: GMAIL_REFRESH_TOKEN/
     );
-    expect(getAccessToken).not.toHaveBeenCalled();
+    expect(https.request).not.toHaveBeenCalled();
   });
 
   it("succeeds on the first attempt when the token exchange works", async () => {
-    getAccessToken.mockResolvedValue({ token: "abc" });
+    queueHttps([{ status: 200, body: { access_token: "abc" } }]);
     await expect(preflightSecrets()).resolves.toBeUndefined();
-    expect(getAccessToken).toHaveBeenCalledTimes(1);
+    expect(https.request).toHaveBeenCalledTimes(1);
   });
 
   it("retries a transient 'Premature close' failure and then succeeds", async () => {
-    getAccessToken
-      .mockRejectedValueOnce(new Error("Premature close"))
-      .mockRejectedValueOnce(new Error("Premature close"))
-      .mockResolvedValue({ token: "abc" });
-
+    queueHttps([
+      { networkError: "Premature close" },
+      { networkError: "Premature close" },
+      { status: 200, body: { access_token: "abc" } },
+    ]);
     await expect(preflightSecrets()).resolves.toBeUndefined();
-    expect(getAccessToken).toHaveBeenCalledTimes(3);
+    expect(https.request).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries a request timeout and then succeeds", async () => {
+    queueHttps([{ timeout: true }, { status: 200, body: { access_token: "abc" } }]);
+    await expect(preflightSecrets()).resolves.toBeUndefined();
+    expect(https.request).toHaveBeenCalledTimes(2);
   });
 
   it("gives up after exhausting retries on persistent transient failures", async () => {
-    getAccessToken.mockRejectedValue(new Error("Premature close"));
-
+    queueHttps([
+      { networkError: "Premature close" },
+      { networkError: "Premature close" },
+      { networkError: "Premature close" },
+      { networkError: "Premature close" },
+    ]);
     await expect(preflightSecrets()).rejects.toThrow(
-      /Gmail OAuth2 token exchange failed: Error: Premature close/
+      /Gmail OAuth2 token exchange failed:.*Premature close/
     );
     // Initial attempt + OAUTH_MAX_RETRIES (3) = 4 total calls.
-    expect(getAccessToken).toHaveBeenCalledTimes(4);
+    expect(https.request).toHaveBeenCalledTimes(4);
   });
 
   it("does NOT retry a permanent credential error (invalid_grant)", async () => {
-    getAccessToken.mockRejectedValue(new Error("invalid_grant"));
-
+    queueHttps([
+      { status: 400, body: { error: "invalid_grant", error_description: "Token has been expired or revoked." } },
+    ]);
     await expect(preflightSecrets()).rejects.toThrow(
-      /Gmail OAuth2 token exchange failed: Error: invalid_grant/
+      /Gmail OAuth2 token exchange failed:.*invalid_grant/
     );
-    expect(getAccessToken).toHaveBeenCalledTimes(1);
+    expect(https.request).toHaveBeenCalledTimes(1);
   });
 
-  it("treats an empty token as a failure and retries", async () => {
-    getAccessToken
-      .mockResolvedValueOnce({ token: null })
-      .mockResolvedValue({ token: "abc" });
-
+  it("treats a 200 with no access_token as a retryable failure", async () => {
+    queueHttps([{ status: 200, body: {} }, { status: 200, body: { access_token: "abc" } }]);
     await expect(preflightSecrets()).resolves.toBeUndefined();
-    expect(getAccessToken).toHaveBeenCalledTimes(2);
+    expect(https.request).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Problem

The Weekly Audition Checker cron has failed on **every run since June 25** (runs #70, #71, #72), always at the same point in preflight:

```
Fatal error: Error: Gmail OAuth2 token exchange failed: Error: Invalid response body
while trying to fetch https://oauth2.googleapis.com/token: Premature close
    at preflightSecrets (src/preflight.ts:48:11)
```

Runs #68/#69 (June 18/22) succeeded, so this is a regression with no code change on our side.

## Root cause

The error string `"Invalid response body while trying to fetch … Premature close"` is thrown by **node-fetch v2**, which `googleapis` uses under the hood via `gaxios@^6`. It is a known node-fetch keep-alive bug that surfaces on recent Node runtimes (the workflow pins Node `24`, which floats to the latest 24.x on the runner — the most likely trigger between the last green and first red run). It is **not** a credential rejection — a bad refresh token would come back as `invalid_grant`.

## Fix

- **Perform the token exchange over Node's native `https`** — a direct `POST` to `oauth2.googleapis.com/token` with the refresh-token grant, fully bypassing `gaxios`/node-fetch. This matches the project's existing "no external HTTP library" convention (see `scraper.ts`/`github.ts`) and removes the actual culprit from the critical path. Includes a 15s request timeout.
- **Retry with exponential backoff** (3 retries, 2s base) around the exchange, so any genuinely transient transport drop no longer aborts the whole weekly run.
- **Fail fast on real credential errors** — `invalid_grant` / `invalid_client` / `unauthorized_client` are classified as permanent and are not retried.

## Tests

New `tests/preflight.test.ts` drives the native `https` path via a scriptable `https.request` mock:
- success on first attempt
- retry-then-succeed on `Premature close`
- retry-then-succeed on request timeout
- retry exhaustion → clean aggregated error
- fail-fast (no retry) on `invalid_grant`
- retry on a `200` with no `access_token`
- missing-env-var validation

Full suite: **136 passing**, typecheck clean.

## Note / residual risk

`src/email.ts` sends the digest through the same `googleapis` Gmail client, so it uses the same node-fetch stack. That path only executes when an email is actually sent, and the run has never gotten past preflight to reach it. If a future run clears preflight but then fails on send with the same `Premature close`, the send path can be hardened as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMs9dKhJXeqhBNwL16L63W

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMs9dKhJXeqhBNwL16L63W)_