### PR TITLE
fix: Gmail send hardening, at-least-once delivery, and French-horn exclusion

### DIFF
--- a/audition-state.json
+++ b/audition-state.json
@@ -147,13 +147,10 @@
       "url": "https://usarmyband.com/vacancies/",
       "name": "U.S. Army Pershing's Own",
       "lastChecked": "2026-07-02T14:20:01.452Z",
-      "contentHash": "aab1bceb189b0997",
+      "contentHash": "",
       "extractedSummary": "The U.S. Army Band \"Pershing's Own\" has current vacancies for Trumpet and Horn. The Trumpet position has an application deadline of August 20 and audition dates of October 15-16. The Horn position has an application deadline of August 24 and an audition date of October 5. All auditions are held in Arlington, Virginia.",
       "hasRelevantAuditions": true,
-      "notifiedRelevantItems": [
-        "trumpet",
-        "horn"
-      ]
+      "notifiedRelevantItems": []
     }
   },
   "playbillIndexHash": "1a5b5d71d4715e0e",

--- a/src/check-auditions.ts
+++ b/src/check-auditions.ts
@@ -333,6 +333,11 @@ async function main(): Promise<void> {
 
   console.log("\n▶️  Starting main run\n");
   const allFindings: CrawlResult[] = [];
+  // Standard-page states that carry an unsent finding are held here and only committed to
+  // `state` after the digest email succeeds — so a send failure leaves the page's old
+  // content hash / notified items intact and the finding re-notifies next run (at-least-once,
+  // matching the Playbill `notified` flow).
+  const pendingStandardPageStates = new Map<string, PageState>();
 
   let stateValid = false;
   try {
@@ -370,11 +375,12 @@ async function main(): Promise<void> {
         });
 
         if (result.action === "skip-unchanged") continue;
-        if (result.action === "skip-no-brass" || result.action === "analyzed") {
-          state.pages[urlConfig.url] = result.pageState;
-        }
         if (result.action === "analyzed" && result.finding) {
+          // Defer committing this page's advanced state until the email actually sends.
+          pendingStandardPageStates.set(urlConfig.url, result.pageState);
           allFindings.push(result.finding);
+        } else if (result.action === "skip-no-brass" || result.action === "analyzed") {
+          state.pages[urlConfig.url] = result.pageState;
         }
       } catch (err) {
         if (err instanceof DailyQuotaExhaustedError) throw err;
@@ -430,6 +436,10 @@ async function main(): Promise<void> {
     console.log(`\n📬 Sending email (${reason})...`);
     try {
       await sendEmail(allFindings, probeFailures);
+      // Commit deferred standard-page states now that the email actually sent.
+      for (const [url, pageState] of pendingStandardPageStates) {
+        state.pages[url] = pageState;
+      }
       // Mark Playbill findings as notified only after successful email send
       for (const finding of allFindings.filter((f) => f.source === "playbill")) {
         if (state.playbillListings[finding.url]) {
@@ -440,7 +450,10 @@ async function main(): Promise<void> {
       saveState(state);
     } catch (emailErr) {
       console.error("Notification Failure:", emailErr);
-      // State is already saved — do not re-throw so the Action build succeeds
+      // Deferred standard-page states are intentionally NOT committed here, so the
+      // unsent finding is re-detected and re-notified on the next run. State saved
+      // in the finally block above (without those pages) — do not re-throw so the
+      // Action build succeeds.
     }
   } else {
     console.log("\n✅ No new relevant auditions found. No email sent.");

--- a/src/check-auditions.ts
+++ b/src/check-auditions.ts
@@ -139,6 +139,23 @@ export function canonicalizeLabel(label: string): string {
   return l; // fallback: lowercase + stripped
 }
 
+// Non-trumpet instruments that must never count as a relevant item on their own. `\bhorn\b`
+// matches French/English horn as a whole word while leaving "flugelhorn" (a trumpet-family
+// instrument) untouched; any item that also names trumpet/cornet is preserved so a combined
+// "Trumpet & Horn" posting still qualifies. Extend TRUMPET_FAMILY / add patterns here to
+// exclude other non-trumpet brass (trombone, tuba, euphonium) if desired.
+const EXCLUDED_INSTRUMENT = /\bhorn\b/i;
+const TRUMPET_FAMILY = /\b(trumpet|cornet|flugelhorn)\b/i;
+
+/**
+ * True when an LLM-returned item names a non-trumpet instrument (e.g. French horn) and does
+ * NOT also mention trumpet/cornet/flugelhorn. Used to strip such items before they can be
+ * saved or trigger a notification — the checker is trumpet-only.
+ */
+export function isExcludedInstrument(item: string): boolean {
+  return EXCLUDED_INSTRUMENT.test(item) && !TRUMPET_FAMILY.test(item);
+}
+
 /**
  * Determines whether a standard page should trigger a new user notification.
  *
@@ -230,6 +247,15 @@ export async function processStandardUrl(params: ProcessStandardUrlParams): Prom
   }
 
   const analysis = await analyzeWithLlm(llm, analysisText, urlConfig.url, urlConfig.name);
+
+  // Drop non-trumpet instruments (e.g. French horn) so they are never saved or notified.
+  // If the ONLY relevant items were excluded, the page is not trumpet-relevant for this user.
+  const filteredItems = analysis.relevantItems.filter((i) => !isExcludedInstrument(i));
+  if (analysis.relevantItems.length > 0 && filteredItems.length === 0) {
+    analysis.hasRelevantAuditions = false;
+  }
+  analysis.relevantItems = filteredItems;
+  analysis.instrument = analysis.instrument.filter((i) => !isExcludedInstrument(i));
 
   console.log(
     `  → Relevant: ${analysis.hasRelevantAuditions} | Items: ${analysis.relevantItems.length}`

--- a/src/email.ts
+++ b/src/email.ts
@@ -1,5 +1,7 @@
 import { google } from "googleapis";
 
+import { exchangeRefreshTokenForAccessToken, withOAuthRetry } from "./oauth";
+
 // ─── Shared types ─────────────────────────────────────────────────────────────
 
 export interface UrlConfig {
@@ -124,10 +126,10 @@ export async function sendEmail(
     );
   }
 
-  // Build OAuth2 client and set credentials
+  // Build the Gmail client. Credentials are set per-attempt inside the retry block below
+  // using a natively-fetched access token, so googleapis never performs its own
+  // gaxios/node-fetch token refresh (the source of the "Premature close" send failures).
   const oauth2Client = new google.auth.OAuth2(clientId, clientSecret);
-  oauth2Client.setCredentials({ refresh_token: refreshToken });
-
   const gmail = google.gmail({ version: "v1", auth: oauth2Client });
 
   const today = new Date().toLocaleDateString("en-US", {
@@ -195,18 +197,26 @@ export async function sendEmail(
   });
 
   const labelName = process.env.GMAIL_LABEL_NAME;
-  if (labelName) {
-    const labelId = await getOrCreateLabel(gmail, labelName);
-    await gmail.users.messages.insert({
-      userId: "me",
-      requestBody: { raw, labelIds: [labelId, "INBOX"] },
-    });
-    console.log(`✉️  Email inserted into mailbox with label "${labelName}" for ${notifyEmail}`);
-  } else {
-    await gmail.users.messages.send({
-      userId: "me",
-      requestBody: { raw },
-    });
-    console.log(`✉️  Email sent to ${notifyEmail}`);
-  }
+
+  // Retry the whole send: each attempt mints a fresh access token via native https and
+  // hands it to the client, so a transient "Premature close" drop no longer silently
+  // discards a notification. Permanent credential errors fail fast (see withOAuthRetry).
+  await withOAuthRetry(async () => {
+    oauth2Client.setCredentials({ access_token: await exchangeRefreshTokenForAccessToken() });
+
+    if (labelName) {
+      const labelId = await getOrCreateLabel(gmail, labelName);
+      await gmail.users.messages.insert({
+        userId: "me",
+        requestBody: { raw, labelIds: [labelId, "INBOX"] },
+      });
+      console.log(`✉️  Email inserted into mailbox with label "${labelName}" for ${notifyEmail}`);
+    } else {
+      await gmail.users.messages.send({
+        userId: "me",
+        requestBody: { raw },
+      });
+      console.log(`✉️  Email sent to ${notifyEmail}`);
+    }
+  }, "Gmail send");
 }

--- a/src/llm-classifiers.ts
+++ b/src/llm-classifiers.ts
@@ -22,8 +22,8 @@ export async function analyzeWithLlm(
 
   const prompt = `Classify this orchestra page for trumpet audition relevance.
 
-RELEVANT: audition/position with a future date (after ${today}) that involves trumpet, brass, or an open orchestral audition where trumpet would qualify (e.g. a sub list open to any instrument).
-NOT RELEVANT: past auditions, admin/education-only roles, instruments that exclude brass.
+RELEVANT: audition/position with a future date (after ${today}) that involves trumpet (or cornet/flugelhorn), or an open orchestral audition where trumpet would qualify (e.g. a sub list open to any instrument).
+NOT RELEVANT: past auditions, admin/education-only roles, or positions for other instruments only — including French horn or English horn, which are NOT trumpet. A horn-only opening is not relevant unless the same audition also includes trumpet.
 
 Return JSON only — no prose, no markdown fences:
 {

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -1,0 +1,113 @@
+import * as https from "https";
+
+// ─── Gmail OAuth2 (native https) ──────────────────────────────────────────────
+//
+// Both the preflight credential check and the email send obtain a Gmail access
+// token here, using Node's native `https` module rather than the googleapis /
+// gaxios client. gaxios v6 performs its fetch through node-fetch v2, which throws
+// "Invalid response body ... Premature close" (ERR_STREAM_PREMATURE_CLOSE) when the
+// keep-alive connection to `oauth2.googleapis.com` is closed early on recent Node
+// runtimes — the failure that was aborting the weekly run. Native `https` is not
+// subject to that bug and matches the project's "no external HTTP library" convention.
+
+export const OAUTH_MAX_RETRIES = 3;
+export const OAUTH_BASE_DELAY_MS = 2000;
+
+/**
+ * A permanent OAuth2 failure (bad/expired/revoked credentials) is not worth retrying —
+ * Google surfaces these as `invalid_grant`/`invalid_client`/`unauthorized_client`. Every
+ * other failure (e.g. "Premature close", ECONNRESET, socket hang up, timeouts) is a
+ * transient transport error where the credentials never got judged, so a retry can succeed.
+ */
+export function isPermanentOAuthError(err: unknown): boolean {
+  const msg = String(err instanceof Error ? err.message : err).toLowerCase();
+  return (
+    msg.includes("invalid_grant") ||
+    msg.includes("invalid_client") ||
+    msg.includes("unauthorized_client")
+  );
+}
+
+/**
+ * Exchanges the refresh token for an access token via a direct POST to Google's OAuth
+ * endpoint using Node's native `https` module. A genuine credential rejection comes back
+ * as a 400 with an `invalid_grant` body, which `isPermanentOAuthError` detects.
+ */
+export function exchangeRefreshTokenForAccessToken(): Promise<string> {
+  const body = new URLSearchParams({
+    client_id: process.env.GMAIL_CLIENT_ID!,
+    client_secret: process.env.GMAIL_CLIENT_SECRET!,
+    refresh_token: process.env.GMAIL_REFRESH_TOKEN!,
+    grant_type: "refresh_token",
+  }).toString();
+
+  return new Promise<string>((resolve, reject) => {
+    const req = https.request(
+      {
+        hostname: "oauth2.googleapis.com",
+        path: "/token",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Content-Length": Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          let parsed: { access_token?: string; error?: string; error_description?: string };
+          try {
+            parsed = JSON.parse(data);
+          } catch {
+            reject(new Error(`Unexpected token endpoint response (${res.statusCode}): ${data}`));
+            return;
+          }
+          if (res.statusCode === 200 && parsed.access_token) {
+            resolve(parsed.access_token);
+          } else {
+            // Surface Google's `error` (e.g. invalid_grant) so isPermanentOAuthError can classify it.
+            reject(
+              new Error(
+                `${parsed.error ?? `HTTP ${res.statusCode}`}${parsed.error_description ? `: ${parsed.error_description}` : ""}`
+              )
+            );
+          }
+        });
+      }
+    );
+    req.on("error", reject);
+    req.setTimeout(15000, () => {
+      req.destroy();
+      reject(new Error("Token request timed out"));
+    });
+    req.write(body);
+    req.end();
+  });
+}
+
+/**
+ * Runs an OAuth-dependent operation with exponential backoff. Transient transport drops
+ * (e.g. "Premature close") are retried; permanent credential errors fail fast. Used to wrap
+ * both the preflight token check and the Gmail send so a single dropped connection to
+ * Google does not abort the run or silently lose a notification.
+ */
+export async function withOAuthRetry<T>(op: () => Promise<T>, label: string): Promise<T> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= OAUTH_MAX_RETRIES; attempt++) {
+    try {
+      return await op();
+    } catch (err) {
+      lastErr = err;
+      if (isPermanentOAuthError(err) || attempt === OAUTH_MAX_RETRIES) {
+        throw err;
+      }
+      const delayMs = OAUTH_BASE_DELAY_MS * 2 ** attempt;
+      console.log(
+        `  ⏳ ${label} failed (${err}) — retry ${attempt + 1}/${OAUTH_MAX_RETRIES} in ${Math.round(delayMs / 1000)}s...`
+      );
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+  throw lastErr;
+}

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -1,95 +1,11 @@
-import * as https from "https";
-
 import { LlmClient, DailyQuotaExhaustedError } from "./llm";
 
 import { MIN_CONTENT_LENGTH, fetchPage, fetchWithFirecrawl, stripHtml, extractMainContent } from "./scraper";
 import { UrlConfig, ProbeFailure } from "./email";
 import { probeIsAuditionPage } from "./llm-classifiers";
+import { exchangeRefreshTokenForAccessToken, withOAuthRetry } from "./oauth";
 
 // ─── Preflight: secrets ───────────────────────────────────────────────────────
-
-const OAUTH_MAX_RETRIES = 3;
-const OAUTH_BASE_DELAY_MS = 2000;
-
-/**
- * A permanent OAuth2 failure (bad/expired/revoked credentials) is not worth retrying —
- * Google surfaces these as `invalid_grant`/`invalid_client`/`unauthorized_client`. Every
- * other failure (e.g. "Premature close", ECONNRESET, socket hang up, timeouts) is a
- * transient transport error where the credentials never got judged, so a retry can succeed.
- */
-function isPermanentOAuthError(err: unknown): boolean {
-  const msg = String(err instanceof Error ? err.message : err).toLowerCase();
-  return (
-    msg.includes("invalid_grant") ||
-    msg.includes("invalid_client") ||
-    msg.includes("unauthorized_client")
-  );
-}
-
-/**
- * Exchanges the refresh token for an access token via a direct POST to Google's OAuth
- * endpoint using Node's native `https` module.
- *
- * We deliberately bypass the `googleapis`/`gaxios` client here: gaxios v6 performs its
- * fetch through node-fetch v2, which throws "Invalid response body ... Premature close"
- * when the keep-alive connection to `oauth2.googleapis.com` is closed early on recent
- * Node runtimes — the exact failure that was aborting the weekly run every time. Native
- * `https` (already the project's preferred HTTP mechanism, see scraper.ts) is not subject
- * to that node-fetch bug. A genuine credential rejection still comes back as a 400 with an
- * `invalid_grant` body, which `isPermanentOAuthError` detects so we fail fast.
- */
-function exchangeRefreshTokenForAccessToken(): Promise<string> {
-  const body = new URLSearchParams({
-    client_id: process.env.GMAIL_CLIENT_ID!,
-    client_secret: process.env.GMAIL_CLIENT_SECRET!,
-    refresh_token: process.env.GMAIL_REFRESH_TOKEN!,
-    grant_type: "refresh_token",
-  }).toString();
-
-  return new Promise<string>((resolve, reject) => {
-    const req = https.request(
-      {
-        hostname: "oauth2.googleapis.com",
-        path: "/token",
-        method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-          "Content-Length": Buffer.byteLength(body),
-        },
-      },
-      (res) => {
-        let data = "";
-        res.on("data", (chunk) => (data += chunk));
-        res.on("end", () => {
-          let parsed: { access_token?: string; error?: string; error_description?: string };
-          try {
-            parsed = JSON.parse(data);
-          } catch {
-            reject(new Error(`Unexpected token endpoint response (${res.statusCode}): ${data}`));
-            return;
-          }
-          if (res.statusCode === 200 && parsed.access_token) {
-            resolve(parsed.access_token);
-          } else {
-            // Surface Google's `error` (e.g. invalid_grant) so isPermanentOAuthError can classify it.
-            reject(
-              new Error(
-                `${parsed.error ?? `HTTP ${res.statusCode}`}${parsed.error_description ? `: ${parsed.error_description}` : ""}`
-              )
-            );
-          }
-        });
-      }
-    );
-    req.on("error", reject);
-    req.setTimeout(15000, () => {
-      req.destroy();
-      reject(new Error("Token request timed out"));
-    });
-    req.write(body);
-    req.end();
-  });
-}
 
 /**
  * Validates not just presence but actual usability of credentials by performing a
@@ -97,10 +13,10 @@ function exchangeRefreshTokenForAccessToken(): Promise<string> {
  * fetching or state mutation occurs, so a credential failure produces a clean error
  * rather than a partially-completed run with no email sent.
  *
- * The token exchange is retried with exponential backoff because the request to
- * Google's OAuth endpoint occasionally drops mid-flight (e.g. "Premature close") on
- * CI runners — a transport hiccup that should not abort the entire weekly run. Genuine
- * credential rejections fail fast without retrying.
+ * The token exchange (native https — see ./oauth) is retried with exponential backoff
+ * because the request to Google's OAuth endpoint occasionally drops mid-flight (e.g.
+ * "Premature close") on CI runners — a transport hiccup that should not abort the entire
+ * weekly run. Genuine credential rejections fail fast without retrying.
  */
 export async function preflightSecrets(): Promise<void> {
   console.log("🔐 Preflight: checking secrets...");
@@ -122,23 +38,17 @@ export async function preflightSecrets(): Promise<void> {
   }
   console.log("  ✓ All required env vars present");
 
-  // Verify OAuth2 token exchange actually works (native https — see helper for rationale)
-  for (let attempt = 0; attempt <= OAUTH_MAX_RETRIES; attempt++) {
-    try {
-      const token = await exchangeRefreshTokenForAccessToken();
-      if (!token) throw new Error("Empty access token returned");
-      console.log("  ✓ Gmail OAuth2 token exchange successful");
-      return;
-    } catch (err) {
-      if (isPermanentOAuthError(err) || attempt === OAUTH_MAX_RETRIES) {
-        throw new Error(`Gmail OAuth2 token exchange failed: ${err}`);
-      }
-      const delayMs = OAUTH_BASE_DELAY_MS * 2 ** attempt;
-      console.log(
-        `  ⏳ Gmail OAuth2 token exchange failed (${err}) — retry ${attempt + 1}/${OAUTH_MAX_RETRIES} in ${Math.round(delayMs / 1000)}s...`
-      );
-      await new Promise((r) => setTimeout(r, delayMs));
-    }
+  // Verify OAuth2 token exchange actually works (native https — see ./oauth for rationale)
+  try {
+    const token = await withOAuthRetry(async () => {
+      const t = await exchangeRefreshTokenForAccessToken();
+      if (!t) throw new Error("Empty access token returned");
+      return t;
+    }, "Gmail OAuth2 token exchange");
+    if (!token) throw new Error("Empty access token returned");
+    console.log("  ✓ Gmail OAuth2 token exchange successful");
+  } catch (err) {
+    throw new Error(`Gmail OAuth2 token exchange failed: ${err}`);
   }
 }
 

--- a/tests/check-auditions.test.ts
+++ b/tests/check-auditions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { encodeSubjectRfc2047, buildEmailRaw } from "../src/email";
-import { shouldNotify, canonicalizeLabel, processStandardUrl, PageState } from "../src/check-auditions";
+import { shouldNotify, canonicalizeLabel, isExcludedInstrument, processStandardUrl, PageState } from "../src/check-auditions";
 import { computePageHash } from "../src/scraper";
 import type { LlmClient } from "../src/llm";
 
@@ -298,6 +298,87 @@ describe("processStandardUrl", () => {
 
     expect(result.action).toBe("skip-no-brass");
     expect(client.generate).not.toHaveBeenCalled();
+  });
+
+  it("strips French horn from a trumpet+horn page but still notifies for trumpet", async () => {
+    const client = makeClient(vi.fn().mockResolvedValue(JSON.stringify({
+      isRelevant: true,
+      instrument: ["Principal Trumpet", "Principal Horn"],
+      deadline: "2026-08-20",
+      location: "Arlington, VA",
+      confidenceScore: 0.95,
+      summary: "Trumpet and Horn vacancies.",
+      futureDates: ["2026-10-15"],
+      relevantItems: ["Principal Trumpet", "Principal Horn"],
+    })));
+
+    const result = await processStandardUrl({
+      llm: client,
+      urlConfig: TEST_URL,
+      text: BRASS_PAGE_TEXT,
+      html: "",
+      previousState: undefined,
+    });
+
+    expect(result.action).toBe("analyzed");
+    if (result.action === "analyzed") {
+      expect(result.finding).not.toBeNull();
+      expect(result.finding!.relevantItems).toEqual(["Principal Trumpet"]);
+      expect(result.pageState.hasRelevantAuditions).toBe(true);
+      expect(result.pageState.notifiedRelevantItems).not.toContain("horn");
+    }
+  });
+
+  it("does not notify when the only relevant item is French horn", async () => {
+    // Page passes the brass gate (mentions trumpet) but the LLM's only item is horn.
+    const client = makeClient(vi.fn().mockResolvedValue(JSON.stringify({
+      isRelevant: true,
+      instrument: ["Principal Horn"],
+      deadline: "2026-08-24",
+      location: "Arlington, VA",
+      confidenceScore: 0.9,
+      summary: "Horn vacancy.",
+      futureDates: ["2026-10-05"],
+      relevantItems: ["Principal Horn"],
+    })));
+
+    const result = await processStandardUrl({
+      llm: client,
+      urlConfig: TEST_URL,
+      text: BRASS_PAGE_TEXT,
+      html: "",
+      previousState: undefined,
+    });
+
+    expect(result.action).toBe("analyzed");
+    if (result.action === "analyzed") {
+      expect(result.finding).toBeNull();
+      expect(result.pageState.hasRelevantAuditions).toBe(false);
+    }
+  });
+});
+
+describe("isExcludedInstrument", () => {
+  it("excludes French and English horn", () => {
+    expect(isExcludedInstrument("Principal Horn")).toBe(true);
+    expect(isExcludedInstrument("French Horn")).toBe(true);
+    expect(isExcludedInstrument("Section Horn")).toBe(true);
+    expect(isExcludedInstrument("English Horn")).toBe(true);
+  });
+
+  it("does not exclude trumpet-family instruments", () => {
+    expect(isExcludedInstrument("Principal Trumpet")).toBe(false);
+    expect(isExcludedInstrument("Section Cornet")).toBe(false);
+    expect(isExcludedInstrument("Flugelhorn")).toBe(false); // trumpet family — 'horn' not a whole word
+  });
+
+  it("keeps a combined position that also names trumpet", () => {
+    expect(isExcludedInstrument("Trumpet & Horn")).toBe(false);
+  });
+
+  it("does not exclude unrelated non-horn items", () => {
+    expect(isExcludedInstrument("Sub List")).toBe(false);
+    expect(isExcludedInstrument("Section Trombone")).toBe(false);
   });
 });
 

--- a/tests/email.test.ts
+++ b/tests/email.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for the hardened Gmail send in sendEmail. The send now mints an access token via
+ * the native-https OAuth helper and retries the whole send on transient transport drops
+ * (e.g. "Premature close"), so a single dropped connection no longer silently discards a
+ * notification. Permanent credential errors (invalid_grant) fail fast.
+ */
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+
+// Hoisted so the vi.mock factories (also hoisted) can reference these mocks safely.
+const { messagesSend, messagesInsert, labelsList, labelsCreate, setCredentials, exchangeToken } =
+  vi.hoisted(() => ({
+    messagesSend: vi.fn(),
+    messagesInsert: vi.fn(),
+    labelsList: vi.fn(),
+    labelsCreate: vi.fn(),
+    setCredentials: vi.fn(),
+    exchangeToken: vi.fn(),
+  }));
+
+vi.mock("googleapis", () => ({
+  google: {
+    auth: {
+      OAuth2: class {
+        setCredentials = setCredentials;
+      },
+    },
+    gmail: () => ({
+      users: {
+        messages: { send: messagesSend, insert: messagesInsert },
+        labels: { list: labelsList, create: labelsCreate },
+      },
+    }),
+  },
+}));
+
+// Keep the real withOAuthRetry (so retry/backoff is exercised) but stub the token fetch.
+vi.mock("../src/oauth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/oauth")>();
+  return { ...actual, exchangeRefreshTokenForAccessToken: exchangeToken };
+});
+
+import { sendEmail, CrawlResult } from "../src/email";
+
+const FINDING: CrawlResult = {
+  source: "standard",
+  name: "Test Orchestra",
+  url: "https://example.com/auditions",
+  summary: "Trumpet audition",
+  relevantItems: ["Principal Trumpet"],
+  futureDates: [],
+};
+
+const REQUIRED_ENV = {
+  GMAIL_CLIENT_ID: "id",
+  GMAIL_CLIENT_SECRET: "secret",
+  GMAIL_REFRESH_TOKEN: "refresh",
+  GMAIL_USER: "user@example.com",
+  NOTIFY_EMAIL: "notify@example.com",
+};
+
+describe("sendEmail — Gmail send hardening", () => {
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(process.env, REQUIRED_ENV);
+    delete process.env.GMAIL_LABEL_NAME;
+    exchangeToken.mockResolvedValue("access-token-abc");
+    // Instant backoff.
+    vi.spyOn(global, "setTimeout").mockImplementation(((cb: () => void) => {
+      cb();
+      return 0 as unknown as NodeJS.Timeout;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any);
+  });
+
+  afterEach(() => {
+    process.env = { ...savedEnv };
+    vi.restoreAllMocks();
+  });
+
+  it("sends via messages.send and sets a natively-fetched access token", async () => {
+    messagesSend.mockResolvedValue({});
+    await expect(sendEmail([FINDING])).resolves.toBeUndefined();
+    expect(exchangeToken).toHaveBeenCalledTimes(1);
+    expect(setCredentials).toHaveBeenCalledWith({ access_token: "access-token-abc" });
+    expect(messagesSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries the send on a transient 'Premature close' and then succeeds", async () => {
+    messagesSend
+      .mockRejectedValueOnce(new Error("Invalid response body ... Premature close"))
+      .mockResolvedValue({});
+    await expect(sendEmail([FINDING])).resolves.toBeUndefined();
+    // Two send attempts, each preceded by a fresh token fetch.
+    expect(messagesSend).toHaveBeenCalledTimes(2);
+    expect(exchangeToken).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after exhausting retries on persistent transient failures", async () => {
+    messagesSend.mockRejectedValue(new Error("Premature close"));
+    await expect(sendEmail([FINDING])).rejects.toThrow(/Premature close/);
+    // Initial + 3 retries = 4 attempts.
+    expect(messagesSend).toHaveBeenCalledTimes(4);
+  });
+
+  it("fails fast (no retry) when the token exchange returns invalid_grant", async () => {
+    exchangeToken.mockRejectedValue(new Error("invalid_grant: Token has been expired or revoked."));
+    await expect(sendEmail([FINDING])).rejects.toThrow(/invalid_grant/);
+    expect(exchangeToken).toHaveBeenCalledTimes(1);
+    expect(messagesSend).not.toHaveBeenCalled();
+  });
+
+  it("uses messages.insert with a label when GMAIL_LABEL_NAME is set", async () => {
+    process.env.GMAIL_LABEL_NAME = "Auditions";
+    labelsList.mockResolvedValue({ data: { labels: [{ name: "Auditions", id: "Label_1" }] } });
+    messagesInsert.mockResolvedValue({});
+    await expect(sendEmail([FINDING])).resolves.toBeUndefined();
+    expect(messagesInsert).toHaveBeenCalledTimes(1);
+    expect(messagesSend).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Context

Follow-up to #33. That PR fixed the OAuth `Premature close` failure in **preflight**. Run #74 (the first run on `main` afterward) got past preflight, found a real new match (**U.S. Army Pershing's Own — Trumpet, Horn**), and tried to email it — then hit the **same node-fetch bug in the email send path**, which #33 did not touch:

```
📬 Sending email (1 orchestra finding(s))...
Notification Failure: GaxiosError: Invalid response body while trying to fetch
https://oauth2.googleapis.com/token: Premature close   (ERR_STREAM_PREMATURE_CLOSE)
    at async sendEmail (src/email.ts:206:5)
```

The send failed inside googleapis' implicit OAuth token refresh, the email never went out, **but the job still exited 0** so it looked green. That same run also revealed that "horn" was being treated as trumpet-relevant.

## Bugs fixed

1. **`email.ts` used the vulnerable stack.** `gmail.users.messages.send()` triggers a gaxios/node-fetch token refresh — the exact code path that premature-closes.
2. **Notifications could be lost permanently.** For standard URLs, the finding was marked notified (content hash + `notifiedRelevantItems`) and persisted **before** the email was sent. A failed send left the page marked "seen", so the next run skipped it as unchanged and never re-notified. (The Playbill path already only sets `notified` after a successful send.)
3. **French horn counted as trumpet-relevant.** "Horn" ≠ trumpet, but it was saved and would appear in the digest.

## Changes

- **`src/oauth.ts` (new):** native-`https` token exchange (shared by preflight + email) + `withOAuthRetry` — exponential backoff, fail-fast on `invalid_grant`/`invalid_client`/`unauthorized_client`.
- **`email.ts`:** mint the access token via native `https` per attempt and set it on the client so googleapis never does its own node-fetch refresh; retry the whole send on transient drops.
- **`check-auditions.ts` (delivery):** defer committing a standard page's advanced state until the digest email actually sends — at-least-once, matching the Playbill flow. A send failure now re-notifies next run instead of silently dropping the finding.
- **`check-auditions.ts` (relevance):** new `isExcludedInstrument()` strips French/English horn from `relevantItems`/`instrument`. It matches `horn` as a whole word, so **flugelhorn** (trumpet family) and any combined "Trumpet & Horn" item are preserved. If a page's only relevant items were horn, it is marked not relevant. (A horn-only page already fails the trumpet/cornet brass gate; this covers pages that also mention trumpet.)
- **`llm-classifiers.ts`:** prompt now states French/English horn are not relevant unless the same audition also includes trumpet.
- **`preflight.ts`:** rewired to the shared `oauth.ts` helpers (behavior unchanged).
- **Recovery:** reset `U.S. Army Pershing's Own` state (`contentHash` → `""`, `notifiedRelevantItems` → `[]`) so the next run re-detects and emails it — now trumpet-only (deadline Aug 20, audition Oct 15–16).

## Tests

- New `tests/email.test.ts`: send success (+ native token set), transient `Premature close` retry-then-succeed, retry exhaustion, `invalid_grant` fail-fast, and the label/`messages.insert` path.
- New `check-auditions.test.ts` cases: `isExcludedInstrument` (horn excluded, flugelhorn/trumpet preserved), trumpet+horn page notifies with horn stripped, horn-only page does not notify.
- Existing `tests/preflight.test.ts` still passes through the extracted module.
- Full suite: **147 passing**, typecheck clean.

## Verification note

The send hardening is covered by unit tests (no live email is possible here). The real end-to-end confirmation is the next run on `main` after merge: it should re-detect U.S. Army and actually deliver a trumpet-only email. I can watch that run and confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMs9dKhJXeqhBNwL16L63W